### PR TITLE
Override faux-bolding for headings

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -105,6 +105,7 @@ header {
 
 h1 {
   margin-bottom: 0;
+  font-weight: normal;
 }
 
 header h1 a {


### PR DESCRIPTION
Prevents User Agent Stylesheet from faux-bolding the h1 font.